### PR TITLE
Couldn't delete a bucket

### DIFF
--- a/lib/aws/s3/bucket.rb
+++ b/lib/aws/s3/bucket.rb
@@ -271,8 +271,10 @@ module AWS
       
       # Delete all files in the bucket. Use with caution. Can not be undone.
       def delete_all
-        each do |object|
-          object.delete
+        while(size > 0) do
+          each do |object|
+            object.delete
+          end
         end
         self
       end


### PR DESCRIPTION
Bucket.delete('some_bucket', :force => true) was failing with BucketNotEmpty, and I realized it was because delete_all was only deleting the first 1000 objects, then attempting to delete the bucket.

This worked for me.
