### PR TITLE
supporting extended (accents) characters on copy/rename operations

### DIFF
--- a/lib/aws/s3/acl.rb
+++ b/lib/aws/s3/acl.rb
@@ -562,7 +562,7 @@ module AWS
             path   = path!(bucket, name) << '?acl'
 
             respond_with ACL::Policy::Response do
-              policy ? put(path, {}, policy.to_xml) : ACL::Policy.new(get(path).policy)
+              policy ? put(path, {}, policy.to_xml) : ACL::Policy.new(get(bucket, path).policy)
             end
           end
         end

--- a/lib/aws/s3/authentication.rb
+++ b/lib/aws/s3/authentication.rb
@@ -61,7 +61,6 @@ module AWS
         private
     
           def canonical_string            
-            options = {}
             options[:expires] = expires if expires?
             CanonicalString.new(request, options)
           end
@@ -156,7 +155,7 @@ module AWS
           # "For non-authenticated or anonymous requests. A NotImplemented error result code will be returned if 
           # an authenticated (signed) request specifies a Host: header other than 's3.amazonaws.com'"
           # (from http://docs.amazonwebservices.com/AmazonS3/2006-03-01/VirtualHosting.html)
-          request['Host'] = DEFAULT_HOST
+          request['Host'] ||= DEFAULT_HOST
           build
         end
     
@@ -173,7 +172,7 @@ module AWS
               self << (key =~ self.class.amazon_header_prefix ? "#{key}:#{value}" : value)
               self << "\n"
             end
-            self << path
+            self << "/#{@options[:bucket]}#{path}"
           end
       
           def initialize_headers

--- a/lib/aws/s3/base.rb
+++ b/lib/aws/s3/base.rb
@@ -63,10 +63,10 @@ module AWS #:nodoc:
         #
         # It is unlikely that you would call this method directly. Subclasses of Base have convenience methods for each http request verb
         # that wrap calls to request.
-        def request(verb, path, options = {}, body = nil, attempts = 0, &block)
+        def request(verb, bucket, path, options = {}, body = nil, attempts = 0, &block)
           Service.response = nil
           process_options!(options, verb)
-          response = response_class.new(connection.request(verb, path, options, body, attempts, &block))
+          response = response_class.new(connection.request(verb, bucket, path, options, body, attempts, &block))
           Service.response = response
 
           Error::Response.new(response.response).error.raise if response.error?
@@ -85,8 +85,8 @@ module AWS #:nodoc:
 
         [:get, :post, :put, :delete, :head].each do |verb|
           class_eval(<<-EVAL, __FILE__, __LINE__)
-            def #{verb}(path, headers = {}, body = nil, &block)
-              request(:#{verb}, path, headers, body, &block)
+            def #{verb}(bucket, path, headers = {}, body = nil, &block)
+              request(:#{verb}, bucket, path, headers, body, &block)
             end
           EVAL
         end

--- a/lib/aws/s3/bucket.rb
+++ b/lib/aws/s3/bucket.rb
@@ -76,7 +76,7 @@ module AWS
         # in the section called 'Setting access levels'.
         def create(name, options = {})
           validate_name!(name)
-          put("/#{name}", options).success?
+          put(nil, "/#{name}", options).success?
         end
         
         # Fetches the bucket named <tt>name</tt>. 
@@ -99,7 +99,7 @@ module AWS
         # There are several options which allow you to limit which objects are retrieved. The list of object filtering options
         # are listed in the documentation for Bucket.objects.
         def find(name = nil, options = {})
-          new(get(path(name, options)).bucket)
+          new(get(bucket_name(name), path(name, options)).bucket)
         end
         
         # Return just the objects in the bucket named <tt>name</tt>.
@@ -178,7 +178,7 @@ module AWS
               options = name
               name    = nil
             end
-            "/#{bucket_name(name)}#{RequestOptions.process(options).to_query_string}"
+            "/#{RequestOptions.process(options).to_query_string}"
           end
       end
       

--- a/lib/aws/s3/object.rb
+++ b/lib/aws/s3/object.rb
@@ -182,7 +182,7 @@ module AWS
         def copy(key, copy_key, bucket = nil, options = {})
           bucket          = bucket_name(bucket)
           source_key      = path!(bucket, key)
-          default_options = {'x-amz-copy-source' => source_key}
+          default_options = {'x-amz-copy-source' => URI.escape(source_key)}
           target_key      = path!(bucket, copy_key)
           returning put(target_key, default_options) do
             acl(copy_key, bucket, acl(key, bucket)) if options[:copy_acl]

--- a/lib/aws/s3/object.rb
+++ b/lib/aws/s3/object.rb
@@ -189,6 +189,18 @@ module AWS
           end
         end
         
+        # Makes a copy of the object with <tt>key</tt> to <tt>copy_key</tt>, preserving the ACL of the existing object if the <tt>:copy_acl</tt> option is true (default false).
+        def copy_to_bucket(key, copy_key, source_bucket, destination_bucket, options = {})
+          source_bucket       = bucket_name(source_bucket)
+          destination_bucket  = bucket_name(destination_bucket)
+          source_key          = path_with_bucket!(source_bucket, key)
+          default_options     = {'x-amz-copy-source' => URI.escape(source_key)}
+          target_key          = path!(copy_key)
+          returning put(destination_bucket, target_key, default_options.merge(options)) do
+            acl(copy_key, destination_bucket, acl(key, source_bucket)) if options[:copy_acl]
+          end
+        end
+        
         # Rename the object with key <tt>from</tt> to have key in <tt>to</tt>.
         def rename(from, to, bucket = nil, options = {})
           copy(from, to, bucket, options)

--- a/test/remote/object_test.rb
+++ b/test/remote/object_test.rb
@@ -176,6 +176,26 @@ class RemoteS3ObjectTest < Test::Unit::TestCase
     assert_equal object.value, copy.value
     assert_equal object.content_type, copy.content_type
     
+    # Test copy to an filename with an accent
+    copy_to_accent = nil
+    assert_nothing_raised do
+      object.copy('testing_s3objects-copy-to-accent-é')
+      copy_to_accent = S3Object.find('testing_s3objects-copy-to-accent-é', TEST_BUCKET)
+      assert        copy_to_accent
+      assert_equal  copy_to_accent.value,         object.value
+      assert_equal  copy_to_accent.content_type,  object.content_type
+    end
+    
+    # Test copy from an filename with an accent
+    assert_nothing_raised do
+      object_with_accent = S3Object.find('testing_s3objects-copy-to-accent-é')
+      object_with_accent.copy('testing_s3objects-copy-from-accent')
+      copy_from_accent = S3Object.find('testing_s3objects-copy-from-accent', TEST_BUCKET)
+      assert        copy_from_accent
+      assert_equal  copy_from_accent.value,         object_with_accent.value
+      assert_equal  copy_from_accent.content_type,  object_with_accent.content_type
+    end    
+    
     # Delete object
     
     assert_nothing_raised do


### PR DESCRIPTION
Hi,

I'm not sure this gem is still supported, by since we are using it and starting to make modifications.

Here is a small patch to supporte copy/rename operations on file with accents. The signature was not computed correctly since the original key had to be escaped and was not.

Let me know if you are still supporting this gem or where should I re-route my request.

And thanks for that simply working gem :)
