### PR TITLE
Escape characters on #prepare_path method

### DIFF
--- a/lib/aws/s3/connection.rb
+++ b/lib/aws/s3/connection.rb
@@ -8,7 +8,7 @@ module AWS
         
         def prepare_path(path)
           path = path.remove_extended unless path.valid_utf8?
-          URI.escape(path)
+          URI.escape(path).gsub('+', '%2B').gsub('[', '%5B').gsub(']', '%5D')
         end
       end
       


### PR DESCRIPTION
Escape +, [ and ] characters properly on #prepare_path method
