### PR TITLE
Fix for EU-Buckets

### DIFF
--- a/lib/aws/s3/authentication.rb
+++ b/lib/aws/s3/authentication.rb
@@ -156,7 +156,8 @@ module AWS
           # "For non-authenticated or anonymous requests. A NotImplemented error result code will be returned if 
           # an authenticated (signed) request specifies a Host: header other than 's3.amazonaws.com'"
           # (from http://docs.amazonwebservices.com/AmazonS3/2006-03-01/VirtualHosting.html)
-          request['Host'] = DEFAULT_HOST
+          # ... and now CanonicalString will be fix if request['Host'] is set
+          # request['Host'] = DEFAULT_HOST
           build
         end
     
@@ -213,7 +214,13 @@ module AWS
           end
           
           def only_path
-            request.path[/^[^?]*/]
+            # Check if a VirtualHost "bucket.s3.amazonaws.com" is set
+            # If the the path in the canonical string has to be "/bucket/request_path"
+            if ( request['Host'] =~ /^(.+)\.s3\.amazonaws\.com$/ )
+              '/' + $1 + request.path[/^[^?]*/]
+            else
+              request.path[/^[^?]*/]
+            end
           end
       end
     end

--- a/lib/aws/s3/base.rb
+++ b/lib/aws/s3/base.rb
@@ -66,23 +66,6 @@ module AWS #:nodoc:
         def request(verb, path, options = {}, body = nil, attempts = 0, &block)
           Service.response = nil
           process_options!(options, verb)
-
-          # Quick and dirty fix to access buckets the VirtualHost-way
-          # / => goes to "s3.amazonaws.com" /
-          # /bucket => goes to "bucket.s3.amazonaws.com" /
-          # /bucket/key => goest to "bucket.s3.amazonaws.com" /key
-          case path
-            when /^\/(\?.*)?$/ then
-              path = '/' + ($1 || '')
-              options['Host'] = DEFAULT_HOST
-            when /^\/([^\?\/]+)(\?.*)?$/ then
-              path = '/' + ($2 || '')
-              options['Host'] = $1 + '.' + DEFAULT_HOST
-            when /^\/([^\?\/]+)([^\?]+)(\?.*)?$/ then
-              path = $2 + ($3 || '')
-              options['Host'] = host = $1 + '.' + DEFAULT_HOST    
-          end
-
           response = response_class.new(connection.request(verb, path, options, body, attempts, &block))
           Service.response = response
 

--- a/lib/aws/s3/base.rb
+++ b/lib/aws/s3/base.rb
@@ -66,6 +66,23 @@ module AWS #:nodoc:
         def request(verb, path, options = {}, body = nil, attempts = 0, &block)
           Service.response = nil
           process_options!(options, verb)
+
+          # Quick and dirty fix to access buckets the VirtualHost-way
+          # / => goes to "s3.amazonaws.com" /
+          # /bucket => goes to "bucket.s3.amazonaws.com" /
+          # /bucket/key => goest to "bucket.s3.amazonaws.com" /key
+          case path
+            when /^\/(\?.*)?$/ then
+              path = '/' + ($1 || '')
+              options['Host'] = DEFAULT_HOST
+            when /^\/([^\?\/]+)(\?.*)?$/ then
+              path = '/' + ($2 || '')
+              options['Host'] = $1 + '.' + DEFAULT_HOST
+            when /^\/([^\?\/]+)([^\?]+)(\?.*)?$/ then
+              path = $2 + ($3 || '')
+              options['Host'] = host = $1 + '.' + DEFAULT_HOST    
+          end
+
           response = response_class.new(connection.request(verb, path, options, body, attempts, &block))
           Service.response = response
 

--- a/lib/aws/s3/connection.rb
+++ b/lib/aws/s3/connection.rb
@@ -26,6 +26,8 @@ module AWS
       def request(verb, path, headers = {}, body = nil, attempts = 0, &block)
         body.rewind if body.respond_to?(:rewind) unless attempts.zero?      
         
+        path = virtual_host_fix(path, headers)
+        
         requester = Proc.new do 
           path    = self.class.prepare_path(path) if attempts.zero? # Only escape the path once
           request = request_method(verb).new(path, headers)
@@ -61,13 +63,35 @@ module AWS
         # Default to true unless explicitly false
         authenticate = true if authenticate.nil? 
         path         = self.class.prepare_path(path)
-        request      = request_method(:get).new(path, {})
+
+        headers = {}
+        path = virtual_host_fix(path, headers)
+        
+        request      = request_method(:get).new(path, headers)
         query_string = query_string_authentication(request, options)
         returning "#{protocol(options)}#{http.address}#{port_string}#{path}" do |url|
           url << "?#{query_string}" if authenticate
         end
       end
       
+      def virtual_host_fix(path, headers)
+        # Quick and dirty fix to access buckets the VirtualHost-way
+        # / => goes to "s3.amazonaws.com" /
+        # /bucket => goes to "bucket.s3.amazonaws.com" /
+        # /bucket/key => goest to "bucket.s3.amazonaws.com" /key
+        case path
+          when /^\/(\?.*)?$/ then
+            headers['Host'] = DEFAULT_HOST
+            return '/' + ($1 || '')
+          when /^\/([^\?\/]+)(\?.*)?$/ then
+            headers['Host'] = $1 + '.' + DEFAULT_HOST
+            return '/' + ($2 || '')
+          when /^\/([^\?\/]+)([^\?]+)(\?.*)?$/ then
+            headers['Host'] = host = $1 + '.' + DEFAULT_HOST    
+            return $2 + ($3 || '')
+        end        
+      end
+
       def subdomain
         http.address[/^([^.]+).#{DEFAULT_HOST}$/, 1]
       end


### PR DESCRIPTION
To access EU-Buckets one HAS to use the VirtualHost-method to address buckets, i.e. instead of
GET /bucket/somekey
Host: s3.amazonaws.com
it has to be
GET /somekey
Host: bucket.s3.amazonaws.com

Yet the canonical string for authorization remains the same for both.
This fix is a quick&dirty soluation that works for me so far. Though it is still necessary to set the ":server" option in establish_connection!. Maybe this should be set as well (at least for :persistent => false)
