### PR TITLE
added missing canned ACLs

### DIFF
--- a/lib/aws/s3/acl.rb
+++ b/lib/aws/s3/acl.rb
@@ -624,7 +624,7 @@ module AWS
           end
 
           def valid_levels
-            %w(private public-read public-read-write authenticated-read)
+            %w(private public-read public-read-write authenticated-read bucket-owner-read bucket-owner-full-control)
           end
 
           def access_level


### PR DESCRIPTION
I just changed AWS::S3::ACL::OptionParser's private valid_levels to include this missing bucket-owner-read bucket-owner-full-control canned ACLs as defined in: http://jurgens-nettuts-tutorial.s3.amazonaws.com/s3-api.pdf
