### PR TITLE
Prepare path escaping

### DIFF
--- a/lib/aws/s3/connection.rb
+++ b/lib/aws/s3/connection.rb
@@ -8,7 +8,8 @@ module AWS
         
         def prepare_path(path)
           path = path.remove_extended unless path.valid_utf8?
-          URI.escape(path)
+          chars_to_escape = /[!*'();:@&=+$,\?#\[\]\s]/ # rfc3986, without /, plus space
+          URI.escape( path, chars_to_escape )
         end
       end
       

--- a/test/connection_test.rb
+++ b/test/connection_test.rb
@@ -121,7 +121,12 @@ class ConnectionTest < Test::Unit::TestCase
     flexmock(connection.http).should_receive(:request).ordered
     connection.request :put, unescaped_path
   end
-  
+
+  def test_prepare_path_percent_escapes_spaces
+    assert_equal 'foo%20bar%20baz',
+                 Connection.prepare_path('foo bar baz')
+  end
+
   def test_if_request_has_no_body_then_the_content_length_is_set_to_zero
     # References bug: http://rubyforge.org/tracker/index.php?func=detail&aid=13052&group_id=2409&atid=9356
     connection = Connection.new(@keys)

--- a/test/connection_test.rb
+++ b/test/connection_test.rb
@@ -127,6 +127,22 @@ class ConnectionTest < Test::Unit::TestCase
                  Connection.prepare_path('foo bar baz')
   end
 
+  def test_url_for_escapes_file_paths_with_reserved_characters
+    reserved_chars = '!*\'();:@&=+$,?#[ ]' # rfc3986, without /, plus space
+    connection =
+      Connection.new(:access_key_id => '123', :secret_access_key => 'abc', :port => 80)
+    assert_match(
+      /http:\/\/s3.amazonaws.com\/Foo\/%21%2A%27%28%29%3B%3A%40%26%3D%2B%24%2C%3F%23%5B%20%5D\/foo\/bar\?AWSAccessKeyId=[^&]*&Expires=[^&]*&Signature=.*$/,
+      AWS::S3::S3Object.url_for("#{reserved_chars}/foo/bar", 'Foo')
+    )
+  end  
+
+  def test_prepare_path_escapes_all_uri_reserved_charachters_except_slash
+    reserved_chars = '!*\'();:@&=+$,?#[ ]' # rfc3986, without /, plus space
+    assert_equal '%21%2A%27%28%29%3B%3A%40%26%3D%2B%24%2C%3F%23%5B%20%5D/foo/bar',
+                 Connection.prepare_path("#{reserved_chars}/foo/bar")
+  end
+
   def test_if_request_has_no_body_then_the_content_length_is_set_to_zero
     # References bug: http://rubyforge.org/tracker/index.php?func=detail&aid=13052&group_id=2409&atid=9356
     connection = Connection.new(@keys)


### PR DESCRIPTION
Currently, if a file on s3 has a URI reserved character in its name, it's possible for it to make its way into the URL.

Some browsers make a correct guess about dealing with this, and others don't. Depending on one's definition of correct. The point is, they will make different guesses, resulting in the timeout signature being incorrect in some cases.
