### PR TITLE
clean up auth and allow specifying request parameters

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -58,16 +58,15 @@ end
 
 namespace :dist do  
   spec = Gem::Specification.new do |s|
-    s.name              = 'aws-s3'
+    s.name              = 'aws-s3-instructure'
     s.version           = Gem::Version.new(AWS::S3::Version)
     s.summary           = "Client library for Amazon's Simple Storage Service's REST API"
-    s.description       = s.summary
-    s.email             = 'marcel@vernix.org'
-    s.author            = 'Marcel Molina Jr.'
+    s.description       = "Client library for Amazon's Simple Storage Service's REST API, forked by Instructure pending action on pull request https://github.com/marcel/aws-s3/pull/40"
+    s.email             = 'jacob@instructure.com'
+    s.author            = 'Jacob Fugal'
     s.has_rdoc          = true
     s.extra_rdoc_files  = %w(README COPYING INSTALL)
     s.homepage          = 'http://amazon.rubyforge.org'
-    s.rubyforge_project = 'amazon'
     s.files             = FileList['Rakefile', 'lib/**/*.rb', 'bin/*', 'support/**/*.rb']
     s.executables       << 's3sh'
     s.test_files        = Dir['test/**/*']
@@ -131,39 +130,6 @@ namespace :dist do
   end
   
   package_name = lambda {|specification| File.join('pkg', "#{specification.name}-#{specification.version}")}
-  
-  desc 'Push a release to rubyforge'
-  task :release => [:confirm_release, :clean, :add_release_marker_to_changelog, :package, :commit_changelog, :tag] do 
-    require 'rubyforge'
-    package = package_name[spec]
-
-    rubyforge = RubyForge.new.configure
-    rubyforge.login
-    
-    user_config = rubyforge.userconfig
-    user_config['release_changes'] = YAML.load_file('CHANGELOG')[spec.version.to_s].join("\n")
-  
-    version_already_released = lambda do
-      releases = rubyforge.autoconfig['release_ids']
-      releases.has_key?(spec.name) && releases[spec.name][spec.version.to_s]
-    end
-    
-    abort("Release #{spec.version} already exists!") if version_already_released.call
-    
-    begin
-      rubyforge.add_release(spec.rubyforge_project, spec.name, spec.version.to_s, "#{package}.tar.gz", "#{package}.gem")
-      puts "Version #{spec.version} released!"
-    rescue Exception => exception
-      puts 'Release failed!'
-      raise
-    end
-  end
-  
-  desc 'Upload a beta gem'
-  task :push_beta_gem => [:clobber_package, :package] do
-    beta_gem = package_name[spec]
-    sh %(scp #{beta_gem}.gem  marcel@rubyforge.org:/var/www/gforge-projects/amazon/beta)
-  end
   
   task :spec do
     puts spec.to_ruby

--- a/lib/aws/s3/authentication.rb
+++ b/lib/aws/s3/authentication.rb
@@ -61,7 +61,7 @@ module AWS
         private
     
           def canonical_string            
-            options = {}
+            options = @options.slice(*CanonicalString::SIGNIFICANT_PARAMETERS)
             options[:expires] = expires if expires?
             CanonicalString.new(request, options)
           end

--- a/test/authentication_test.rb
+++ b/test/authentication_test.rb
@@ -99,6 +99,11 @@ class CanonicalStringTest < Test::Unit::TestCase
     end
   end
   
+  def test_path_includes_significant_query_strings_from_options
+    assert_equal '/test/query/string?acl=foo', Authentication::CanonicalString.new(Net::HTTP::Get.new('/test/query/string'), :acl => 'foo').send(:path)
+    assert_equal '/test/query/string?acl&torrent=foo', Authentication::CanonicalString.new(Net::HTTP::Get.new('/test/query/string?acl'), :torrent => 'foo').send(:path)
+  end
+  
   def test_path_includes_significant_query_strings_with_unencoded_values
     # "When signing you do not encode these values. However, when making the
     # request, you must encode these parameter values."


### PR DESCRIPTION
See commit messages for details. Out immediate use case is being able to specify response-content-disposition when generating our S3 GET urls. I noticed the auth deficiencies while adding that.
