### PR TITLE
clean up auth and allow specifying request parameters

### DIFF
--- a/lib/aws/s3/authentication.rb
+++ b/lib/aws/s3/authentication.rb
@@ -61,7 +61,7 @@ module AWS
         private
     
           def canonical_string            
-            options = {}
+            options = @options.slice(*CanonicalString::SIGNIFICANT_PARAMETERS)
             options[:expires] = expires if expires?
             CanonicalString.new(request, options)
           end

--- a/test/authentication_test.rb
+++ b/test/authentication_test.rb
@@ -99,6 +99,11 @@ class CanonicalStringTest < Test::Unit::TestCase
     end
   end
   
+  def test_path_includes_significant_query_strings_from_options
+    assert_equal '/test/query/string?acl=foo', Authentication::CanonicalString.new(Net::HTTP::Get.new('/test/query/string'), :acl => 'foo').send(:path)
+    assert_equal '/test/query/string?acl&torrent=foo', Authentication::CanonicalString.new(Net::HTTP::Get.new('/test/query/string?acl'), :torrent => 'foo').send(:path)
+  end
+  
   def test_path_includes_significant_query_strings_with_unencoded_values
     # "When signing you do not encode these values. However, when making the
     # request, you must encode these parameter values."


### PR DESCRIPTION
See commit messages for details. Out immediate use case is being able to specify response-content-disposition when generating our S3 GET urls. I noticed the auth deficiencies while adding that.
