### PR TITLE
SyntaxError - invalid multibyte escape: /[\x80-\xFF]/

### DIFF
--- a/lib/aws/s3/extensions.rb
+++ b/lib/aws/s3/extensions.rb
@@ -1,3 +1,4 @@
+#encoding: BINARY
 #:stopdoc:
 
 class Hash


### PR DESCRIPTION
encoding added, because of an error while running rails tests within netbeans: /home/guitarman/sites/r_evolution/fleximage/ruby/1.9.1/gems/aws-s3-0.6.2/lib/aws/s3/extensions.rb:84: invalid multibyte escape: /[\x80-\xFF]/ (SyntaxError)
