### PR TITLE
Use the options passed to S3Object.copy, supporting reduced redundancy

### DIFF
--- a/lib/aws/s3/object.rb
+++ b/lib/aws/s3/object.rb
@@ -184,7 +184,7 @@ module AWS
           source_key      = path!(bucket, key)
           default_options = {'x-amz-copy-source' => source_key}
           target_key      = path!(bucket, copy_key)
-          returning put(target_key, default_options) do
+          returning put(target_key, default_options.merge(options)) do
             acl(copy_key, bucket, acl(key, bucket)) if options[:copy_acl]
           end
         end

--- a/test/object_test.rb
+++ b/test/object_test.rb
@@ -148,6 +148,21 @@ class ObjectTest < Test::Unit::TestCase
       S3Object.about('asdfasdfasdfas-this-does-not-exist', 'bucket does not matter')
     end
   end
+  def test_copy_options_are_used
+    options = {'x-amz-storage-class' => 'REDUCED_REDUNDANCY'}
+    resp = FakeResponse.new
+
+    connection = flexmock('Mock connection') do |mock|
+      mock.should_receive(:request).
+        # The storage-class key must be passed to connection.request(:put, ...)
+        with(:put, '/some-bucket/new', hsh(options), any, any).
+        and_return(resp)
+    end
+    flexmock(S3Object).should_receive(:connection).and_return(connection)
+
+    result = S3Object.copy('old', 'new', 'some-bucket', options)
+    assert_equal resp.code, result.code
+  end
 end
 
 class MetadataTest < Test::Unit::TestCase


### PR DESCRIPTION
I need to enable reduced redundancy on some existing S3 objects.
The typical way to do this is copy the object within S3, supplying the
new storage-class (reduced redundancy) as an option to the copy.
However, aws-s3 is ignoring the copy options, instead only using the
default_options to specify the copy-source.

Update the copy method to merge the copy-source options with the passed
options, so that storage-class can be specified.
