### PR TITLE
Expires time is calculated twice when using expires_in and can cause signature authentication problems

### DIFF
--- a/lib/aws/s3/authentication.rb
+++ b/lib/aws/s3/authentication.rb
@@ -115,7 +115,7 @@ module AWS
           #   3) The current time in seconds since the epoch plus the default number of seconds (60 seconds)
           def expires
             return options[:expires] if options[:expires]
-            @expires || = date.to_i + expires_in
+            @expires ||= date.to_i + expires_in
           end
           
           def expires_in

--- a/lib/aws/s3/authentication.rb
+++ b/lib/aws/s3/authentication.rb
@@ -115,7 +115,7 @@ module AWS
           #   3) The current time in seconds since the epoch plus the default number of seconds (60 seconds)
           def expires
             return options[:expires] if options[:expires]
-            date.to_i + expires_in
+            @expires || = date.to_i + expires_in
           end
           
           def expires_in


### PR DESCRIPTION
@bmo figured this out, I'm just the messenger.

The build method in QueryString calls #expires, and so does #encoded_canonical.

``` ruby
 # Keep in alphabetical order
 def build
   "AWSAccessKeyId=#{access_key_id}&Expires=#{expires}&Signature=#{encoded_canonical}"
 end
```

If these calls lie on separate sides of a second tick the signature will be wrong. The solution is to memoize the first call so encoded_canonical uses the same value.
