### PR TITLE
Support Response Headers in GET requests

### DIFF
--- a/lib/aws/s3/authentication.rb
+++ b/lib/aws/s3/authentication.rb
@@ -156,14 +156,6 @@ module AWS
           def query_parameters_for_signature(params)
             params.select {|k, v| query_parameters.include?(k)}
           end
-
-          def escape(value)
-            CGI::escape(value.to_s).gsub('+', '%20').gsub('%7E', '~')
-          end
-
-          def unescape(value)
-            CGI::unescape(value.to_s.gsub('%20', '+').gsub('~', '%7E'))
-          end
         end
 
         attr_reader :request, :headers

--- a/lib/aws/s3/connection.rb
+++ b/lib/aws/s3/connection.rb
@@ -63,7 +63,7 @@ module AWS
         path         = self.class.prepare_path(path)
         request      = request_method(:get).new(path, {})
         query_string = query_string_authentication(request, options)
-        "#{protocol(options)}#{http.address}#{port_string}#{path}".tap do |url|
+        "#{protocol(options)}#{http.address}#{port_string}#{path[/^[^?]*/]}".tap do |url|
           url << "?#{query_string}" if authenticate
         end
       end

--- a/lib/aws/s3/connection.rb
+++ b/lib/aws/s3/connection.rb
@@ -7,7 +7,8 @@ module AWS
         end
         
         def prepare_path(path)
-          path.valid_utf8? ? path : path.remove_extended
+          path = path.remove_extended unless path.valid_utf8?
+          URI.escape(path)
         end
       end
       
@@ -59,7 +60,7 @@ module AWS
         authenticate = options.delete(:authenticated)
         # Default to true unless explicitly false
         authenticate = true if authenticate.nil? 
-        path         = self.class.prepare_path(path)
+        path         = path.valid_utf8? ? path : path.remove_extended
         request      = request_method(:get).new(path, {})
         query_string = query_string_authentication(request, options)
         "#{protocol(options)}#{http.address}#{port_string}#{path}".tap do |url|

--- a/lib/aws/s3/connection.rb
+++ b/lib/aws/s3/connection.rb
@@ -63,8 +63,8 @@ module AWS
         path         = self.class.prepare_path(path)
         request      = request_method(:get).new(path, {})
         query_string = query_string_authentication(request, options)
-        "#{protocol(options)}#{http.address}#{port_string}#{path[/^[^?]*/]}".tap do |url|
-          url << "?#{query_string}" if authenticate
+        "#{protocol(options)}#{http.address}#{port_string}#{path}".tap do |url|
+          (url << (path[/\?/] ? '&' : '?') << "#{query_string}") if authenticate
         end
       end
       

--- a/lib/aws/s3/connection.rb
+++ b/lib/aws/s3/connection.rb
@@ -7,8 +7,7 @@ module AWS
         end
         
         def prepare_path(path)
-          path = path.remove_extended unless path.valid_utf8?
-          URI.escape(path)
+          path.valid_utf8? ? path : path.remove_extended
         end
       end
       


### PR DESCRIPTION
Hi Marcel. 

This is a **simpler** patch than the one I previously sent you by means of RubyForge. 

Here is a [discussion](https://github.com/aercolino/aws-s3/wiki) about why I'm no longer supporting auto-escaping of path (first arg in url_for). You'll also find additional documentation.

Thanks, 
--Andrea
