### PR TITLE
Update to AWS::S3::Parsing::parser

### DIFF
--- a/lib/aws/s3.rb
+++ b/lib/aws/s3.rb
@@ -57,4 +57,6 @@ AWS::S3::Parsing.parser =
     FasterXmlSimple
   rescue LoadError
     XmlSimple
+  rescue NameError
+    XmlSimple
   end


### PR DESCRIPTION
Extended the error handling for the case where the require_library_or_gem 'xml/libxml' succeeds but the XML::Parser generates a NameError.
