### PR TITLE
add license information to the gemspec

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -78,6 +78,7 @@ namespace :dist do
     s.rdoc_options  = ['--title', "AWS::S3 -- Support for Amazon S3's REST api",
                        '--main',  'README',
                        '--line-numbers', '--inline-source']
+    s.license = "MIT"
   end
     
   # Regenerate README before packaging


### PR DESCRIPTION
This way it can be queried using the rubygems.org API
