### PR TITLE
Retry if connection was reset by peer (ECONNRESET)

### DIFF
--- a/lib/aws/s3/connection.rb
+++ b/lib/aws/s3/connection.rb
@@ -51,7 +51,7 @@ module AWS
         else
           http.start(&requester)
         end
-      rescue Errno::EPIPE, Timeout::Error, Errno::EINVAL, EOFError
+      rescue Errno::EPIPE, Timeout::Error, Errno::EINVAL, EOFError, Errno::ECONNRESET
         @http = create_connection
         attempts == 3 ? raise : (attempts += 1; retry)
       end


### PR DESCRIPTION
This error tends to happen here and there, and deserves similar retry treatment as other Net:HTTP errors.
