### PR TITLE
escaping improvements

### DIFF
--- a/lib/aws/s3.rb
+++ b/lib/aws/s3.rb
@@ -36,6 +36,13 @@ module AWS
       URI.escape(path.to_s, UNSAFE_URI)
     end
 
+    def self.escape_uri_component(path)
+      escaped = escape_uri(path)
+      escaped.gsub!(/=/, '%3D')
+      escaped.gsub!(/&/, '%26')
+      escaped
+    end
+
     Base.class_eval do
       include AWS::S3::Connection::Management
     end

--- a/lib/aws/s3.rb
+++ b/lib/aws/s3.rb
@@ -40,6 +40,7 @@ module AWS
       escaped = escape_uri(path)
       escaped.gsub!(/=/, '%3D')
       escaped.gsub!(/&/, '%26')
+      escaped.gsub!(/;/, '%3B')
       escaped
     end
 

--- a/lib/aws/s3.rb
+++ b/lib/aws/s3.rb
@@ -28,19 +28,30 @@ require 's3/connection'
 require 's3/authentication'
 require 's3/response'
 
-AWS::S3::Base.class_eval do
-  include AWS::S3::Connection::Management
+module AWS
+  module S3
+    UNSAFE_URI = /[^-_.!~*'()a-zA-Z\d;\/?:@&=$,\[\]]/n
+
+    def self.escape_uri(path)
+      URI.escape(path.to_s, UNSAFE_URI)
+    end
+
+    Base.class_eval do
+      include AWS::S3::Connection::Management
+    end
+
+    Bucket.class_eval do
+      include AWS::S3::Logging::Management
+      include AWS::S3::ACL::Bucket
+    end
+
+    S3Object.class_eval do
+      include AWS::S3::ACL::S3Object
+      include AWS::S3::BitTorrent
+    end
+  end
 end
 
-AWS::S3::Bucket.class_eval do
-  include AWS::S3::Logging::Management
-  include AWS::S3::ACL::Bucket
-end
-
-AWS::S3::S3Object.class_eval do
-  include AWS::S3::ACL::S3Object
-  include AWS::S3::BitTorrent
-end
 
 require_library_or_gem 'xmlsimple', 'xml-simple' unless defined? XmlSimple
 # If libxml is installed, we use the FasterXmlSimple library, that provides most of the functionality of XmlSimple

--- a/lib/aws/s3/authentication.rb
+++ b/lib/aws/s3/authentication.rb
@@ -236,7 +236,7 @@ module AWS
             params = self.class.query_parameters_for_signature(params).to_a
             return nil if params.empty?
             params.sort! { |(x_key, _), (y_key, _)| x_key <=> y_key }
-            params.map do |(key, value)|
+            params.map! do |(key, value)|
               if value.nil? || resource_parameter?(key)
                 key
               else

--- a/lib/aws/s3/authentication.rb
+++ b/lib/aws/s3/authentication.rb
@@ -156,6 +156,9 @@ module AWS
           def query_parameters_for_signature(params)
             params.select {|k, v| query_parameters.include?(k)}
           end
+          memoized :default_headers
+          memoized :interesting_headers
+          memoized :query_parameters
         end
 
         attr_reader :request, :headers

--- a/lib/aws/s3/authentication.rb
+++ b/lib/aws/s3/authentication.rb
@@ -156,14 +156,6 @@ module AWS
           def query_parameters_for_signature(params)
             params.select {|k, v| query_parameters.include?(k)}
           end
-
-          def escape(value)
-            CGI::escape(value.to_s).gsub('+', '%20').gsub('%7E', '~')
-          end
-
-          def unescape(value)
-            CGI::unescape(value.to_s.gsub('%20', '+').gsub('~', '%7E'))
-          end
         end
 
         attr_reader :request, :headers

--- a/lib/aws/s3/authentication.rb
+++ b/lib/aws/s3/authentication.rb
@@ -233,13 +233,14 @@ module AWS
             query = URI.parse(request.path).query
             return nil if query.nil?
             params = CGI.parse(query) #this automatically unescapes query params
-            params = self.class.query_parameters_for_signature(params)
+            params = self.class.query_parameters_for_signature(params).to_a
             return nil if params.empty?
             params.sort! { |(x_key, _), (y_key, _)| x_key <=> y_key }
             params.map do |(key, value)|
               if value.nil? || resource_parameter?(key)
                 key
               else
+                value = value.join if value.respond_to?(:join)
                 "#{key}=#{value}"
               end
             end.join("&")

--- a/lib/aws/s3/authentication.rb
+++ b/lib/aws/s3/authentication.rb
@@ -158,7 +158,7 @@ module AWS
           end
 
           def resource_parameters
-            @resource_parameters ||= Set.new %w(acl logging torrent)
+            Set.new %w(acl logging torrent)
           end
 
           memoized :default_headers

--- a/lib/aws/s3/connection.rb
+++ b/lib/aws/s3/connection.rb
@@ -63,7 +63,7 @@ module AWS
         path         = self.class.prepare_path(path)
         request      = request_method(:get).new(path, {})
         query_string = query_string_authentication(request, options)
-        "#{protocol(options)}#{http.address}#{port_string}#{path}".tap do |url|
+        "#{protocol(options)}#{http.address}#{port_string}#{path[/^[^?]*/]}".tap do |url|
           url << "?#{query_string}" if authenticate
         end
       end

--- a/lib/aws/s3/connection.rb
+++ b/lib/aws/s3/connection.rb
@@ -7,7 +7,8 @@ module AWS
         end
         
         def prepare_path(path)
-          path.valid_utf8? ? path : path.remove_extended
+          path = path.remove_extended unless path.valid_utf8?
+          URI.escape(path)
         end
       end
       
@@ -59,7 +60,7 @@ module AWS
         authenticate = options.delete(:authenticated)
         # Default to true unless explicitly false
         authenticate = true if authenticate.nil? 
-        path         = self.class.prepare_path(path)
+        path         = path.valid_utf8? ? path : path.remove_extended
         request      = request_method(:get).new(path, {})
         query_string = query_string_authentication(request, options)
         "#{protocol(options)}#{http.address}#{port_string}#{path}".tap do |url|

--- a/lib/aws/s3/connection.rb
+++ b/lib/aws/s3/connection.rb
@@ -63,8 +63,8 @@ module AWS
         path         = self.class.prepare_path(path)
         request      = request_method(:get).new(path, {})
         query_string = query_string_authentication(request, options)
-        "#{protocol(options)}#{http.address}#{port_string}#{path[/^[^?]*/]}".tap do |url|
-          url << "?#{query_string}" if authenticate
+        "#{protocol(options)}#{http.address}#{port_string}#{path}".tap do |url|
+          (url << (path[/\?/] ? '&' : '?') << "#{query_string}") if authenticate
         end
       end
       

--- a/lib/aws/s3/connection.rb
+++ b/lib/aws/s3/connection.rb
@@ -7,8 +7,7 @@ module AWS
         end
         
         def prepare_path(path)
-          path = path.remove_extended unless path.valid_utf8?
-          URI.escape(path)
+          path.valid_utf8? ? path : path.remove_extended
         end
       end
       

--- a/lib/aws/s3/connection.rb
+++ b/lib/aws/s3/connection.rb
@@ -8,7 +8,7 @@ module AWS
         
         def prepare_path(path)
           path = path.remove_extended unless path.valid_utf8?
-          URI.escape(path)
+          AWS::S3.escape_uri(path)
         end
       end
       

--- a/lib/aws/s3/extensions.rb
+++ b/lib/aws/s3/extensions.rb
@@ -7,7 +7,7 @@ class Hash
     unless empty?
       query_string << '?' if include_question_mark
       query_string << inject([]) do |params, (key, value)| 
-        params << "#{key}=#{AWS::S3.escape_uri(value)}" 
+        params << "#{key}=#{AWS::S3.escape_uri_component(value)}" 
       end.join('&')
     end
     query_string

--- a/lib/aws/s3/extensions.rb
+++ b/lib/aws/s3/extensions.rb
@@ -197,25 +197,7 @@ class Module
       EVAL
     end
   end
-  
-  # Transforms MarcelBucket into
-  #
-  #   class MarcelBucket < AWS::S3::Bucket
-  #     set_current_bucket_to 'marcel'
-  #   end
-  def const_missing_from_s3_library(sym)
-    if sym.to_s =~ /^(\w+)(Bucket|S3Object)$/
-      const = const_set(sym, Class.new(AWS::S3.const_get($2)))
-      const.current_bucket = $1.underscore
-      const
-    else
-      const_missing_not_from_s3_library(sym)
-    end
-  end
-  alias_method :const_missing_not_from_s3_library, :const_missing
-  alias_method :const_missing, :const_missing_from_s3_library
 end
-
 
 class Class # :nodoc:
   def cattr_reader(*syms)

--- a/lib/aws/s3/extensions.rb
+++ b/lib/aws/s3/extensions.rb
@@ -7,7 +7,7 @@ class Hash
     unless empty?
       query_string << '?' if include_question_mark
       query_string << inject([]) do |params, (key, value)| 
-        params << "#{key}=#{value}" 
+        params << "#{key}=#{AWS::S3.escape_uri(value)}" 
       end.join('&')
     end
     query_string

--- a/lib/aws/s3/object.rb
+++ b/lib/aws/s3/object.rb
@@ -297,7 +297,11 @@ module AWS
             options.replace(bucket)
             bucket = nil
           end
-          '/' << File.join(bucket_name(bucket), name)
+          path = '/' << File.join(bucket_name(bucket), name)
+          if (query = options[:query]).respond_to?(:to_query_string)
+            path << query.to_query_string
+          end
+          path
         end
     
         private

--- a/test/authentication_test.rb
+++ b/test/authentication_test.rb
@@ -82,7 +82,8 @@ class CanonicalStringTest < Test::Unit::TestCase
       ['/test/query/string?acl=foo',         '/test/query/string?acl'],
       ['/test/query/string?torrent=foo',     '/test/query/string?torrent'],
       ['/test/query/string?logging=foo',     '/test/query/string?logging'],
-      ['/test/query/string?bar=baz&acl=foo', '/test/query/string?acl']
+      ['/test/query/string?bar=baz&acl=foo', '/test/query/string?acl'],
+      ['/test/query/string?acl&response-content-disposition=1', '/test/query/string?acl&response-content-disposition=1']
     ]
     
     significant_query_strings.each do |uncleaned_path, expected_cleaned_path|

--- a/test/connection_test.rb
+++ b/test/connection_test.rb
@@ -102,6 +102,12 @@ class ConnectionTest < Test::Unit::TestCase
     assert authenticated[connection.url_for('/foo', :authenticated => true)]
     assert !authenticated[connection.url_for('/foo', :authenticated => false)]
   end
+
+  def test_url_for_with_canonical_query_params
+    connection = Connection.new(:access_key_id => '123', :secret_access_key => 'abc', :server => 'example.org')
+    dispositioned = lambda {|url| url['?response-content-disposition=a']}
+    assert dispositioned[connection.url_for("/foo?response-content-disposition=a")]
+  end
   
   def test_connecting_through_a_proxy
     connection = nil

--- a/test/extensions_test.rb
+++ b/test/extensions_test.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 require File.dirname(__FILE__) + '/test_helper'
 
 class HashExtensionsTest < Test::Unit::TestCase

--- a/test/extensions_test.rb
+++ b/test/extensions_test.rb
@@ -29,8 +29,8 @@ class HashExtensionsTest < Test::Unit::TestCase
   end
 
   def test_escape_values
-    hash = {:one => '5+ 1'}
-    assert_equal '?one=5%2B%201', hash.to_query_string
+    hash = {:one => '5+ 1=6&'}
+    assert_equal '?one=5%2B%201%3D6%26', hash.to_query_string
   end
   
   def test_normalized_options

--- a/test/extensions_test.rb
+++ b/test/extensions_test.rb
@@ -26,6 +26,11 @@ class HashExtensionsTest < Test::Unit::TestCase
     qs   = hash.to_query_string
     assert qs['one=1&two=2'] || qs['two=2&one=1']
   end
+
+  def test_escape_values
+    hash = {:one => '5+ 1'}
+    assert_equal '?one=5%2B%201', hash.to_query_string
+  end
   
   def test_normalized_options
     expectations = [

--- a/test/object_test.rb
+++ b/test/object_test.rb
@@ -75,7 +75,7 @@ class ObjectTest < Test::Unit::TestCase
 
     begin
       AWS::S3::Base.connections['AWS::S3::Base'] = conn
-      assert_match 'response-content-disposition=attachment;%20filename%3Dfoo.txt',
+      assert_match 'response-content-disposition=attachment%3B%20filename%3Dfoo.txt',
         @object.url(:query => {
         'response-content-disposition' => 'attachment; filename=foo.txt'})
     ensure


### PR DESCRIPTION
This improves the escaping in AWS-S3.  The main feature we needed was the ability to send response headers we want through an S3 URLs query parameters.

``` ruby
    AWS::S3::S3Object.url_for path, mah_bucket,
      :query => {
        "response-content-disposition" => "attachment; filename=#{name}"},
      :expires => 1.minutes.from_now.to_i
```

We've been running this on GitHub.com for months now without issues.  
