### PR TITLE
add support for eu

### DIFF
--- a/lib/aws/s3/authentication.rb
+++ b/lib/aws/s3/authentication.rb
@@ -174,10 +174,6 @@ module AWS
           @request = request
           @headers = {}
           @options = options
-          # "For non-authenticated or anonymous requests. A NotImplemented error result code will be returned if 
-          # an authenticated (signed) request specifies a Host: header other than 's3.amazonaws.com'"
-          # (from http://docs.amazonwebservices.com/AmazonS3/2006-03-01/VirtualHosting.html)
-          request['Host'] = DEFAULT_HOST
           build
         end
 


### PR DESCRIPTION
allow AWS::S3 to take an option of
:server => 's3-eu-west-1.amazonaws.com'.
and actually pass authentication with it.

These lines aren't necessary anymore for us or eu. And they block the eu connections from working right.
