### PR TITLE
fix the bug in setting http connection's use_ssl option to false.

### DIFF
--- a/lib/aws/s3/connection.rb
+++ b/lib/aws/s3/connection.rb
@@ -98,7 +98,7 @@ module AWS
         
         def create_connection
           http             = http_class.new(options[:server], options[:port])
-          http.use_ssl     = !options[:use_ssl].nil? || options[:port] == 443
+          http.use_ssl     = options[:use_ssl] || options[:port] == 443
           http.verify_mode = OpenSSL::SSL::VERIFY_NONE
           http
         end

--- a/test/connection_test.rb
+++ b/test/connection_test.rb
@@ -15,6 +15,16 @@ class ConnectionTest < Test::Unit::TestCase
     connection = Connection.new(keys.merge(:use_ssl => true))
     assert connection.http.use_ssl?
   end
+
+  def test_use_ssl_option_defaults_to_false_in_connection
+    connection = Connection.new(keys)
+    assert !connection.http.use_ssl?
+  end
+
+  def test_use_ssl_option_is_set_to_false_in_connection
+    connection = Connection.new(keys.merge(:use_ssl => false))
+    assert !connection.http.use_ssl?
+  end
   
   def test_setting_port_to_443_implies_use_ssl
     connection = Connection.new(keys.merge(:port => 443))


### PR DESCRIPTION
if options[:use_ssl] is false, http.use_ssl should be false instead of true.
