### PR TITLE
OpenSSL::Digest::Digest is deprecated; use OpenSSL::Digest instead

### DIFF
--- a/lib/aws/s3/authentication.rb
+++ b/lib/aws/s3/authentication.rb
@@ -68,7 +68,7 @@ module AWS
           memoized :canonical_string
 
           def encoded_canonical
-            digest   = OpenSSL::Digest::Digest.new('sha1')
+            digest   = OpenSSL::Digest.new('sha1')
             b64_hmac = [OpenSSL::HMAC.digest(digest, secret_access_key, canonical_string)].pack("m").strip
             url_encode? ? CGI.escape(b64_hmac) : b64_hmac
           end

--- a/lib/aws/s3/authentication.rb
+++ b/lib/aws/s3/authentication.rb
@@ -68,7 +68,8 @@ module AWS
           memoized :canonical_string
 
           def encoded_canonical
-            digest   = OpenSSL::Digest.new('sha1')
+            klass    = OpenSSL::Digest.respond_to?(:new) ? OpenSSL::Digest : OpenSSL::Digest::Digest
+            digest   = klass.new('sha1')
             b64_hmac = [OpenSSL::HMAC.digest(digest, secret_access_key, canonical_string)].pack("m").strip
             url_encode? ? CGI.escape(b64_hmac) : b64_hmac
           end


### PR DESCRIPTION
This fixes issue #91 by replacing OpenSSL::Digest::Digest (which is deprecated and produces a warning in Ruby 2.1.0) with OpenSSL::Digest
