### PR TITLE
Fix for Rails 4.1.0+

### DIFF
--- a/lib/aws/s3/extensions.rb
+++ b/lib/aws/s3/extensions.rb
@@ -240,7 +240,7 @@ class Class # :nodoc:
     cattr_reader(*syms)
     cattr_writer(*syms)
   end
-end if Class.instance_methods(false).grep(/^cattr_(?:reader|writer|accessor)$/).empty?
+end if Class.instance_methods.grep(/^cattr_(?:reader|writer|accessor)$/).empty?
 
 module SelectiveAttributeProxy
   def self.included(klass)


### PR DESCRIPTION
`cattr_*` methods have been moved to the `Module` in [this commit](https://github.com/rails/rails/commit/7dfbd91b0780fbd6a1dd9bfbc176e10894871d2d).
That resulted in syntax errors from re-defining extension methods:

``` shell
/gems/aws-s3-0.6.3/lib/aws/s3/extensions.rb:223: `@@{' is not allowed as a class variable name
/gems/aws-s3-0.6.3/lib/aws/s3/extensions.rb:223: syntax error, unexpected end-of-input
unless defined? @@{:instance_writer=>true}
^
/gems/aws-s3-0.6.3/lib/aws/s3/extensions.rb:223:in `class_eval'
/gems/aws-s3-0.6.3/lib/aws/s3/extensions.rb:223:in `block in cattr_reader'
/gems/aws-s3-0.6.3/lib/aws/s3/extensions.rb:222:in `each'
/gems/aws-s3-0.6.3/lib/aws/s3/extensions.rb:222:in `cattr_reader'
/gems/aws-s3-0.6.3/lib/aws/s3/extensions.rb:258:in `cattr_accessor'
/gems/activesupport-4.1.0.rc1/lib/active_support/cache.rb:155:in `<class:Store>'
/gems/activesupport-4.1.0.rc1/lib/active_support/cache.rb:154:in `<module:Cache>'
/gems/activesupport-4.1.0.rc1/lib/active_support/cache.rb:14:in `<module:ActiveSupport>'
/gems/activesupport-4.1.0.rc1/lib/active_support/cache.rb:12:in `<top (required)>'
/gems/railties-4.1.0.rc1/lib/rails/application/bootstrap.rb:66:in `block in <module:Bootstrap>'
/gems/railties-4.1.0.rc1/lib/rails/initializable.rb:30:in `instance_exec'
/gems/railties-4.1.0.rc1/lib/rails/initializable.rb:30:in `run'
/gems/railties-4.1.0.rc1/lib/rails/initializable.rb:55:in `block in run_initializers'
/gems/railties-4.1.0.rc1/lib/rails/initializable.rb:54:in `run_initializers'
/gems/railties-4.1.0.rc1/lib/rails/application.rb:286:in `initialize!'
/gems/railties-4.1.0.rc1/lib/rails/railtie.rb:194:in `public_send'
/gems/railties-4.1.0.rc1/lib/rails/railtie.rb:194:in `method_missing'
/app/current/config/environment.rb:5:in `<top (required)>'
/gems/activesupport-4.1.0.rc1/lib/active_support/dependencies.rb:247:in `require'
/gems/activesupport-4.1.0.rc1/lib/active_support/dependencies.rb:247:in `block in require'
/gems/activesupport-4.1.0.rc1/lib/active_support/dependencies.rb:232:in `load_dependency'
/gems/activesupport-4.1.0.rc1/lib/active_support/dependencies.rb:247:in `require'
/gems/railties-4.1.0.rc1/lib/rails/application.rb:262:in `require_environment!'
/gems/railties-4.1.0.rc1/lib/rails/application.rb:346:in `block in run_tasks_blocks'
/gems/sprockets-rails-2.0.1/lib/sprockets/rails/task.rb:54:in `block (2 levels) in define'
```

This change should be backward compatible and work with Rails 4.1.0.
It also makes more sense to check for inherited methods as well.
