### PR TITLE
Sometimes 3rd party S3 services like RadosGW don't have 'message' ele…

### DIFF
--- a/lib/aws/s3/error.rb
+++ b/lib/aws/s3/error.rb
@@ -59,6 +59,8 @@ module AWS
           # We actually want nil if the attribute is nil. So we use has_key? rather than [] + ||.
           if error.has_key?(method.to_s)
             error[method.to_s]
+          elsif method.to_s == 'message'
+            code
           else
             super
           end


### PR DESCRIPTION
…ment in error, so set it to 'code'
