### PR TITLE
Cherry-pick bartoszkopinski's Rails 4.1.0+ fix for aws-s3 onto version 0.6.3

### DIFF
--- a/lib/aws/s3/extensions.rb
+++ b/lib/aws/s3/extensions.rb
@@ -258,7 +258,7 @@ class Class # :nodoc:
     cattr_reader(*syms)
     cattr_writer(*syms)
   end
-end if Class.instance_methods(false).grep(/^cattr_(?:reader|writer|accessor)$/).empty?
+end if Class.instance_methods.grep(/^cattr_(?:reader|writer|accessor)$/).empty?
 
 module SelectiveAttributeProxy
   def self.included(klass)


### PR DESCRIPTION
- [ ] Fork marcel/aws-s3
- [ ] rewind HEAD to commit corresponding to rubygem version 0.6.3
- [ ] manually apply Rails 4.1.0+ syntax fix from https://github.com/marcel/aws-s3/pull/95